### PR TITLE
Extend PyTorch example with training script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The repository includes:
 * ParallelModel class for multi-GPU training
 * Evaluation on MS COCO metrics (AP)
 * Example of training on your own dataset
+* PyTorch demo and training scripts (see `samples/pytorch`)
 
 
 The code is documented and designed to be easy to extend. If you use it in your research, please consider citing this repository (bibtex below). If you work on 3D vision, you might find our recently released [Matterport3D](https://matterport.com/blog/2017/09/20/announcing-matterport3d-research-dataset/) dataset useful as well.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ opencv-python
 h5py
 imgaug
 IPython[all]
+torch
+torchvision

--- a/samples/pytorch/pytorch_mask_rcnn.py
+++ b/samples/pytorch/pytorch_mask_rcnn.py
@@ -1,0 +1,57 @@
+"""PyTorch Mask R-CNN Example
+
+This sample demonstrates running inference with torchvision's
+`maskrcnn_resnet50_fpn` model. It loads a pre-trained model,
+performs instance segmentation on a given image, and displays the
+results using Matplotlib.
+"""
+
+import argparse
+from PIL import Image
+import torch
+import torchvision
+import torchvision.transforms as T
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def run_inference(image_path, threshold=0.7):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = torchvision.models.detection.maskrcnn_resnet50_fpn(pretrained=True)
+    model.to(device)
+    model.eval()
+
+    img = Image.open(image_path).convert("RGB")
+    transform = T.ToTensor()
+    input_tensor = transform(img).to(device)
+
+    with torch.no_grad():
+        outputs = model([input_tensor])[0]
+
+    boxes = outputs['boxes']
+    scores = outputs['scores']
+    masks = outputs['masks']
+
+    fig, ax = plt.subplots(1, figsize=(12, 9))
+    ax.imshow(img)
+    for box, score, mask in zip(boxes, scores, masks):
+        if score < threshold:
+            continue
+        x1, y1, x2, y2 = box.int().tolist()
+        rect = plt.Rectangle((x1, y1), x2 - x1, y2 - y1,
+                              linewidth=2, edgecolor='r', facecolor='none')
+        ax.add_patch(rect)
+        m = mask[0].cpu().numpy()
+        ax.imshow(np.ma.masked_where(m < 0.5, m), alpha=0.5)
+
+    plt.axis('off')
+    plt.show()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="PyTorch Mask R-CNN Example")
+    parser.add_argument("image", help="Path to the input image")
+    parser.add_argument("--threshold", type=float, default=0.7,
+                        help="Score threshold for displaying instances")
+    args = parser.parse_args()
+    run_inference(args.image, args.threshold)

--- a/samples/pytorch/train_pytorch_mask_rcnn.py
+++ b/samples/pytorch/train_pytorch_mask_rcnn.py
@@ -1,0 +1,68 @@
+import os
+import argparse
+
+import torch
+import torchvision
+
+from .utils import PennFudanDataset, collate_fn
+
+
+def train_one_epoch(model, optimizer, data_loader, device):
+    model.train()
+    for images, targets in data_loader:
+        images = list(img.to(device) for img in images)
+        targets = [{k: v.to(device) for k, v in t.items()} for t in targets]
+
+        loss_dict = model(images, targets)
+        losses = sum(loss for loss in loss_dict.values())
+
+        optimizer.zero_grad()
+        losses.backward()
+        optimizer.step()
+
+
+def main(args):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    dataset = PennFudanDataset(args.dataset, train=True)
+    dataset_test = PennFudanDataset(args.dataset, train=False)
+
+    indices = torch.randperm(len(dataset)).tolist()
+    split = int(len(indices) * 0.8)
+    dataset = torch.utils.data.Subset(dataset, indices[:split])
+    dataset_test = torch.utils.data.Subset(dataset_test, indices[split:])
+
+    data_loader = torch.utils.data.DataLoader(
+        dataset, batch_size=2, shuffle=True, num_workers=4, collate_fn=collate_fn
+    )
+    data_loader_test = torch.utils.data.DataLoader(
+        dataset_test, batch_size=1, shuffle=False, num_workers=4, collate_fn=collate_fn
+    )
+
+    num_classes = 2
+    model = torchvision.models.detection.maskrcnn_resnet50_fpn(weights="DEFAULT")
+    in_features = model.roi_heads.box_predictor.cls_score.in_features
+    model.roi_heads.box_predictor = torchvision.models.detection.faster_rcnn.FastRCNNPredictor(
+        in_features, num_classes
+    )
+    in_features_mask = model.roi_heads.mask_predictor.conv5_mask.in_channels
+    hidden_layer = 256
+    model.roi_heads.mask_predictor = torchvision.models.detection.mask_rcnn.MaskRCNNPredictor(
+        in_features_mask, hidden_layer, num_classes
+    )
+
+    model.to(device)
+    params = [p for p in model.parameters() if p.requires_grad]
+    optimizer = torch.optim.SGD(params, lr=0.005, momentum=0.9, weight_decay=0.0005)
+
+    for epoch in range(args.epochs):
+        train_one_epoch(model, optimizer, data_loader, device)
+        torch.save(model.state_dict(), os.path.join(args.output, f"model_{epoch}.pth"))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Train Mask R-CNN on PennFudanPed")
+    parser.add_argument("dataset", help="Path to PennFudanPed root directory")
+    parser.add_argument("--epochs", type=int, default=10, help="Number of training epochs")
+    parser.add_argument("--output", default=".", help="Directory to save checkpoints")
+    args = parser.parse_args()
+    main(args)

--- a/samples/pytorch/utils.py
+++ b/samples/pytorch/utils.py
@@ -1,0 +1,65 @@
+import os
+import numpy as np
+from PIL import Image
+import torch
+import torchvision.transforms as T
+
+
+class PennFudanDataset(torch.utils.data.Dataset):
+    """Dataset for the PennFudanPed pedestrian dataset."""
+
+    def __init__(self, root, train=True):
+        self.root = root
+        self.transforms = self.get_transform(train)
+        self.imgs = list(sorted(os.listdir(os.path.join(root, "PNGImages"))))
+        self.masks = list(sorted(os.listdir(os.path.join(root, "PedMasks"))))
+
+    def get_transform(self, train):
+        transforms = [T.ToTensor()]
+        if train:
+            transforms.append(T.RandomHorizontalFlip(0.5))
+        return T.Compose(transforms)
+
+    def __getitem__(self, idx):
+        img_path = os.path.join(self.root, "PNGImages", self.imgs[idx])
+        mask_path = os.path.join(self.root, "PedMasks", self.masks[idx])
+        img = Image.open(img_path).convert("RGB")
+        mask = np.array(Image.open(mask_path))
+        obj_ids = np.unique(mask)
+        obj_ids = obj_ids[1:]
+        masks = mask == obj_ids[:, None, None]
+        num_objs = len(obj_ids)
+        boxes = []
+        for i in range(num_objs):
+            pos = np.where(masks[i])
+            xmin = np.min(pos[1])
+            xmax = np.max(pos[1])
+            ymin = np.min(pos[0])
+            ymax = np.max(pos[0])
+            boxes.append([xmin, ymin, xmax, ymax])
+        boxes = torch.as_tensor(boxes, dtype=torch.float32)
+        labels = torch.ones((num_objs,), dtype=torch.int64)
+        masks = torch.as_tensor(masks, dtype=torch.uint8)
+
+        image_id = torch.tensor([idx])
+        area = (boxes[:, 3] - boxes[:, 1]) * (boxes[:, 2] - boxes[:, 0])
+        iscrowd = torch.zeros((num_objs,), dtype=torch.int64)
+
+        target = {
+            "boxes": boxes,
+            "labels": labels,
+            "masks": masks,
+            "image_id": image_id,
+            "area": area,
+            "iscrowd": iscrowd,
+        }
+
+        img = self.transforms(img)
+        return img, target
+
+    def __len__(self):
+        return len(self.imgs)
+
+
+def collate_fn(batch):
+    return tuple(zip(*batch))


### PR DESCRIPTION
## Summary
- mention PyTorch scripts in README
- add PennFudan dataset utilities
- provide `train_pytorch_mask_rcnn.py` for training

## Testing
- `python -m py_compile samples/pytorch/pytorch_mask_rcnn.py`
- `python -m py_compile samples/pytorch/train_pytorch_mask_rcnn.py`
- `python -m py_compile samples/pytorch/utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6848c843d7088323b2c0b685ecc0e4d8